### PR TITLE
Update csproj configuration and OpenApiSecurityScheme

### DIFF
--- a/TwitPoster/src/TwitPoster.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/TwitPoster/src/TwitPoster.Web/Extensions/ServiceCollectionExtensions.cs
@@ -33,9 +33,11 @@ public static class ServiceCollectionExtensions
             c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
             {
                 In = ParameterLocation.Header,
-                Description = "Please insert JWT with Bearer into field",
+                Description = "Please enter a valid JWT token (without prefix 'Bearer')",
                 Name = "Authorization",
-                Type = SecuritySchemeType.ApiKey
+                Type = SecuritySchemeType.Http,
+                BearerFormat = "JWT",
+                Scheme = "Bearer"
             });
             c.AddSecurityRequirement(new OpenApiSecurityRequirement
             {

--- a/TwitPoster/src/TwitPoster.Web/TwitPoster.Web.csproj
+++ b/TwitPoster/src/TwitPoster.Web/TwitPoster.Web.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     </PropertyGroup>
 


### PR DESCRIPTION
Removed the RuntimeIdentifier from the csproj configuration to ensure compatibility across various platforms. Updated the OpenApiSecurityScheme description in ServiceCollectionExtensions for better clarity and included Scheme and BearerFormat in the description to enhance user understanding of the token entry process.