### PR TITLE
10.3 Added respawn + web factory fixture PER all tests

### DIFF
--- a/TwitPoster/tests/TwitPoster.IntegrationTests/BaseIntegrationTest.cs
+++ b/TwitPoster/tests/TwitPoster.IntegrationTests/BaseIntegrationTest.cs
@@ -1,45 +1,33 @@
 ﻿using System.Net.Http.Headers;
-using Microsoft.AspNetCore.Mvc.Testing;
+using AutoFixture;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Testcontainers.MsSql;
+using Respawn;
 using TwitPoster.BLL.Interfaces;
 using TwitPoster.DAL;
-using TwitPoster.Web;
+using TwitPoster.DAL.Models;
+using TwitPoster.IntegrationTests.TestData;
 
 namespace TwitPoster.IntegrationTests;
 
 public abstract class BaseIntegrationTest : IAsyncLifetime
 {
-    private readonly MsSqlContainer _msSqlContainer = new MsSqlBuilder().Build();
-    protected IServiceScope Scope = null!;
-    protected TwitPosterContext DbContext = null!;
-    protected HttpClient HttpClient = null!;
-    protected int DefaultUserId = 1;
+    protected readonly IntegrationTestWebFactory Factory;
+    protected readonly IServiceScope Scope;
+    protected readonly TwitPosterContext DbContext;
+    protected readonly HttpClient ApiClient;
     
-    public async Task InitializeAsync()
-    {
-        await _msSqlContainer.StartAsync();
-        
-        var webFactory = new WebApplicationFactory<IApiTestMarker>()
-            .WithWebHostBuilder(b =>
-            {
-                b.ConfigureServices(services =>
-                {
-                    var descriptor = services.SingleOrDefault(
-                        d => d.ServiceType == typeof(DbContextOptions<TwitPosterContext>));
+    protected int DefaultUserId;
 
-                    if (descriptor != null)
-                    {
-                        services.Remove(descriptor);
-                    }
-                
-                    services.AddDbContext<TwitPosterContext>(options => SqlServerDbContextOptionsExtensions.UseSqlServer(options, _msSqlContainer.GetConnectionString()));
-                });
-            });
-        HttpClient = webFactory.CreateClient();
-        Scope = webFactory.Services.CreateScope();
+    protected readonly IntegrationData Data;
+
+    public BaseIntegrationTest(IntegrationTestWebFactory factory)
+    {
+        Factory = factory;
+        Scope = factory.Services.CreateScope();
+        ApiClient = factory.HttpClient;
         DbContext = Scope.ServiceProvider.GetRequiredService<TwitPosterContext>();
+        Data = new IntegrationData(DbContext);
     }
 
     protected async Task AddAuthorization()
@@ -48,11 +36,28 @@ public abstract class BaseIntegrationTest : IAsyncLifetime
         var jwtGenerator = Scope.ServiceProvider.GetRequiredService<IJwtTokenGenerator>();
         var token = jwtGenerator.GenerateToken(user);
 
-        HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        ApiClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await AddDefaultUser();
+    }
+
+    private async Task AddDefaultUser()
+    {
+        var user = Data.BaseFixture.Create<User>();
+        DbContext.Users.Add(user);
+        await DbContext.SaveChangesAsync();
+        DefaultUserId = user.Id;
+        
+        Data.Initialize(user.Id);
     }
 
     public async Task DisposeAsync()
     {
-        await _msSqlContainer.DisposeAsync();
+        await Factory.ResetDatabaseAsync();
+        ApiClient.DefaultRequestHeaders.Authorization = null;
     }
 }
+    

--- a/TwitPoster/tests/TwitPoster.IntegrationTests/BaseIntegrationTest.cs
+++ b/TwitPoster/tests/TwitPoster.IntegrationTests/BaseIntegrationTest.cs
@@ -2,7 +2,6 @@
 using AutoFixture;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Respawn;
 using TwitPoster.BLL.Interfaces;
 using TwitPoster.DAL;
 using TwitPoster.DAL.Models;
@@ -10,6 +9,7 @@ using TwitPoster.IntegrationTests.TestData;
 
 namespace TwitPoster.IntegrationTests;
 
+[Collection(nameof(SharedTestCollection))]
 public abstract class BaseIntegrationTest : IAsyncLifetime
 {
     protected readonly IntegrationTestWebFactory Factory;
@@ -27,6 +27,7 @@ public abstract class BaseIntegrationTest : IAsyncLifetime
         Scope = factory.Services.CreateScope();
         ApiClient = factory.HttpClient;
         DbContext = Scope.ServiceProvider.GetRequiredService<TwitPosterContext>();
+        
         Data = new IntegrationData(DbContext);
     }
 

--- a/TwitPoster/tests/TwitPoster.IntegrationTests/IntegrationTestWebFactory.cs
+++ b/TwitPoster/tests/TwitPoster.IntegrationTests/IntegrationTestWebFactory.cs
@@ -1,0 +1,61 @@
+﻿using System.Data.Common;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Respawn;
+using Testcontainers.MsSql;
+using TwitPoster.DAL;
+using TwitPoster.Web;
+
+namespace TwitPoster.IntegrationTests;
+
+public class IntegrationTestWebFactory : WebApplicationFactory<IApiTestMarker>, IAsyncLifetime
+{
+    private readonly MsSqlContainer _msSqlContainer = new MsSqlBuilder().Build();
+
+    public HttpClient HttpClient { get; private set; } = null!;
+    private DbConnection _dbConnection = null!;
+    private Respawner _respawner = null!;
+    
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<TwitPosterContext>));
+
+            if (descriptor != null)
+            {
+                services.Remove(descriptor);
+            }
+
+            services.AddDbContext<TwitPosterContext>(options => options.UseSqlServer(_msSqlContainer.GetConnectionString()));
+        });
+    }
+    
+    public async Task ResetDatabaseAsync()
+    {
+        await _respawner.ResetAsync(_dbConnection);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _msSqlContainer.StartAsync();
+        _dbConnection = new SqlConnection(_msSqlContainer.GetConnectionString());
+        
+        HttpClient = CreateClient();
+        await _dbConnection.OpenAsync();
+        _respawner = await Respawner.CreateAsync(_dbConnection, new RespawnerOptions
+        {
+            DbAdapter = DbAdapter.SqlServer,
+            SchemasToInclude = new []{ "dbo" },
+        });
+    }
+
+    public new async Task DisposeAsync()
+    {
+        await _msSqlContainer.DisposeAsync();
+    }
+}

--- a/TwitPoster/tests/TwitPoster.IntegrationTests/Post/CreatePostTests.cs
+++ b/TwitPoster/tests/TwitPoster.IntegrationTests/Post/CreatePostTests.cs
@@ -5,7 +5,6 @@ using TwitPoster.Web.ViewModels.Post;
 
 namespace TwitPoster.IntegrationTests.Post;
 
-[Collection(nameof(SharedTestCollection))]
 public class CreatePostsTests : BaseIntegrationTest
 {
     public CreatePostsTests(IntegrationTestWebFactory factory) : base(factory)

--- a/TwitPoster/tests/TwitPoster.IntegrationTests/Post/CreatePostTests.cs
+++ b/TwitPoster/tests/TwitPoster.IntegrationTests/Post/CreatePostTests.cs
@@ -5,28 +5,34 @@ using TwitPoster.Web.ViewModels.Post;
 
 namespace TwitPoster.IntegrationTests.Post;
 
+[Collection(nameof(SharedTestCollection))]
 public class CreatePostsTests : BaseIntegrationTest
 {
+    public CreatePostsTests(IntegrationTestWebFactory factory) : base(factory)
+    {
+    }
+    
     [Fact]
     public async Task Create_Post_should_return_Unauthorized_for_anonymous()
     {
         var request = new CreatePostRequest("Post for integration tests");
-        var createPostResponse = await HttpClient.PostAsJsonAsync("Posts", request);
+        var createPostResponse = await ApiClient.PostAsJsonAsync("Posts", request);
         createPostResponse.Should().Be401Unauthorized();
     }
 
-    
     [Theory, AutoData]
     public async Task Create_Post_should_create_post(CreatePostRequest createPostRequest)
     {
         await AddAuthorization();
 
-        var postsResponse = await HttpClient.PostAsJsonAsync("Posts", createPostRequest);
+        var postsResponse = await ApiClient.PostAsJsonAsync("Posts", createPostRequest);
 
-        postsResponse.Should().Satisfy<PostViewModel>(
+        postsResponse.Should().Be200Ok().
+            And.Satisfy<PostViewModel>(
             postViewmodel =>
                 DbContext.Posts.Should().ContainSingle(p => p.Id == postViewmodel.Id)
                     .Which.Body.Should().Be(createPostRequest.Body)
         );
     }
+
 }

--- a/TwitPoster/tests/TwitPoster.IntegrationTests/Post/GetPostsTests.cs
+++ b/TwitPoster/tests/TwitPoster.IntegrationTests/Post/GetPostsTests.cs
@@ -4,18 +4,17 @@ using TwitPoster.Web.ViewModels.Post;
 
 namespace TwitPoster.IntegrationTests.Post;
 
-[Collection(nameof(SharedTestCollection))]
 public class GetPostsTests : BaseIntegrationTest
 {
     public GetPostsTests(IntegrationTestWebFactory factory) : base(factory)
     {
     }
-    
+
     [Fact]
     public async Task Get_Posts_Returns_Posts()
     {
         var expectedPosts = await Data.AddMany<DAL.Models.Post>();
-        
+
         var postsResponse = await ApiClient.GetAsync("Posts");
         postsResponse.Should()
             .Be200Ok()
@@ -26,7 +25,7 @@ public class GetPostsTests : BaseIntegrationTest
                 x.Should().BeEquivalentTo(expectedPosts, opt => opt.ExcludingMissingMembers());
             });
     }
-    
+
     [Fact]
     public async Task Get_Posts_Returns_Posts_With_isLiked()
     {
@@ -44,7 +43,7 @@ public class GetPostsTests : BaseIntegrationTest
             });
 
         await Data.AddMany(postLikes.ToList());
-        
+
         var postsResponse = await ApiClient.GetAsync("Posts");
         postsResponse.Should()
             .Be200Ok()
@@ -57,4 +56,3 @@ public class GetPostsTests : BaseIntegrationTest
             });
     }
 }
-

--- a/TwitPoster/tests/TwitPoster.IntegrationTests/Post/GetPostsTests.cs
+++ b/TwitPoster/tests/TwitPoster.IntegrationTests/Post/GetPostsTests.cs
@@ -1,33 +1,59 @@
-﻿using AutoFixture;
-using FluentAssertions;
+﻿using FluentAssertions;
+using TwitPoster.DAL.Models;
 using TwitPoster.Web.ViewModels.Post;
 
 namespace TwitPoster.IntegrationTests.Post;
 
+[Collection(nameof(SharedTestCollection))]
 public class GetPostsTests : BaseIntegrationTest
 {
+    public GetPostsTests(IntegrationTestWebFactory factory) : base(factory)
+    {
+    }
+    
     [Fact]
     public async Task Get_Posts_Returns_Posts()
     {
-        var fixture = new Fixture();
-        var expectedPosts = fixture.Build<DAL.Models.Post>()
-            .Without(p => p.Id)
-            .Without(p => p.Author)
-            .Without(p => p.Comments)
-            .Without(p => p.PostLikes)
-            .With(p => p.AuthorId, 1)
-            .CreateMany()
-            .ToList();
-
-        DbContext.Posts.AddRange(expectedPosts);
-        await DbContext.SaveChangesAsync();
+        var expectedPosts = await Data.AddMany<DAL.Models.Post>();
         
-        var postsResponse = await HttpClient.GetAsync("Posts");
+        var postsResponse = await ApiClient.GetAsync("Posts");
         postsResponse.Should()
+            .Be200Ok()
+            .And
             .Satisfy<IReadOnlyList<PostViewModel>>(x =>
             {
                 x.Count.Should().Be(expectedPosts.Count);
                 x.Should().BeEquivalentTo(expectedPosts, opt => opt.ExcludingMissingMembers());
+            });
+    }
+    
+    [Fact]
+    public async Task Get_Posts_Returns_Posts_With_isLiked()
+    {
+        await AddAuthorization();
+        var posts = await Data.AddMany<DAL.Models.Post>(10);
+        var postIds = posts.Select(p => p.Id).ToArray();
+
+        var likedPostIds = Random.Shared.GetItems(postIds.ToArray(), 5).Distinct().ToList();
+
+        var postLikes = likedPostIds
+            .Select(x => new PostLike
+            {
+                PostId = x,
+                UserId = DefaultUserId
+            });
+
+        await Data.AddMany(postLikes.ToList());
+        
+        var postsResponse = await ApiClient.GetAsync("Posts");
+        postsResponse.Should()
+            .Be200Ok()
+            .And
+            .Satisfy<IReadOnlyList<PostViewModel>>(x =>
+            {
+                x.Count.Should().Be(posts.Count);
+                var likedPosts = x.Where(p => p.IsLikedByCurrentUser).Select(p => p.Id).ToList();
+                likedPosts.Should().BeEquivalentTo(likedPostIds);
             });
     }
 }

--- a/TwitPoster/tests/TwitPoster.IntegrationTests/SharedTestCollection.cs
+++ b/TwitPoster/tests/TwitPoster.IntegrationTests/SharedTestCollection.cs
@@ -1,0 +1,7 @@
+namespace TwitPoster.IntegrationTests;
+
+[CollectionDefinition(nameof(SharedTestCollection))]
+public class SharedTestCollection : ICollectionFixture<IntegrationTestWebFactory>
+{
+    
+}

--- a/TwitPoster/tests/TwitPoster.IntegrationTests/TestData/IntegrationData.cs
+++ b/TwitPoster/tests/TwitPoster.IntegrationTests/TestData/IntegrationData.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using Microsoft.EntityFrameworkCore;
+using Bogus;
 using TwitPoster.DAL;
 using TwitPoster.DAL.Models;
 
@@ -13,8 +13,12 @@ public class IntegrationData
     
     public void Initialize(int defaultUserId)
     {
+        var bogus = new Faker();
+
         BaseFixture.Customize<DAL.Models.Post>(x => x
             .With(p => p.AuthorId, defaultUserId)
+            .With(p => p.LikesCount, 0)
+            .With(p => p.Body, bogus.Lorem.Paragraph())
             .Without(p => p.Id)
             .Without(p => p.Author)
             .Without(p => p.Comments)

--- a/TwitPoster/tests/TwitPoster.IntegrationTests/TestData/IntegrationData.cs
+++ b/TwitPoster/tests/TwitPoster.IntegrationTests/TestData/IntegrationData.cs
@@ -1,0 +1,50 @@
+﻿using AutoFixture;
+using Microsoft.EntityFrameworkCore;
+using TwitPoster.DAL;
+using TwitPoster.DAL.Models;
+
+namespace TwitPoster.IntegrationTests.TestData;
+
+public class IntegrationData
+{
+    public Fixture BaseFixture { get; } = new();
+
+    private readonly TwitPosterContext _dbContext;
+    
+    public void Initialize(int defaultUserId)
+    {
+        BaseFixture.Customize<DAL.Models.Post>(x => x
+            .With(p => p.AuthorId, defaultUserId)
+            .Without(p => p.Id)
+            .Without(p => p.Author)
+            .Without(p => p.Comments)
+            .Without(p => p.PostLikes));
+    }
+    
+    public IntegrationData(TwitPosterContext dbContext)
+    {
+        _dbContext = dbContext;
+        BaseFixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
+            .ForEach(b => BaseFixture.Behaviors.Remove(b));
+        BaseFixture.Behaviors.Add(new OmitOnRecursionBehavior());
+        
+        BaseFixture.Customize<User>(x => x.Without(u => u.Id));
+        BaseFixture.Customize<UserAccount>(x => x.Without(u => u.Id).Without(u => u.IsBanned));
+    }
+    
+    public async Task<IReadOnlyList<T>> AddMany<T>(int count = 3) where T : class
+    {
+        var entities = BaseFixture.CreateMany<T>(count).ToList();
+        _dbContext.Set<T>().AddRange(entities);
+        await _dbContext.SaveChangesAsync();
+
+        return entities;
+    }
+    
+    public async Task<IReadOnlyList<T>> AddMany<T>(IReadOnlyList<T> entitiesToAdd) where T : class
+    {
+        _dbContext.Set<T>().AddRange(entitiesToAdd);
+        await _dbContext.SaveChangesAsync();
+        return entitiesToAdd;
+    }
+}

--- a/TwitPoster/tests/TwitPoster.IntegrationTests/TwitPoster.IntegrationTests.csproj
+++ b/TwitPoster/tests/TwitPoster.IntegrationTests/TwitPoster.IntegrationTests.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="FluentAssertions.Web" Version="1.2.5" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.7.23375.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
+        <PackageReference Include="Respawn" Version="6.1.0" />
         <PackageReference Include="Testcontainers" Version="3.4.0" />
         <PackageReference Include="Testcontainers.MsSql" Version="3.4.0" />
         <PackageReference Include="xunit" Version="2.4.2"/>
@@ -31,6 +32,7 @@
     <ItemGroup>
       <ProjectReference Include="..\..\src\TwitPoster.Web\TwitPoster.Web.csproj" />
     </ItemGroup>
+
 
 
 </Project>


### PR DESCRIPTION
Created a shared `IntegrationTestWebFactory` for all tests to set up required configurations, improving the DRY principle. Test cases now are using `ApiClient` which is configured in `IntegrationTestWebFactory`, instead of a local `HttpClient`. New