### PR TITLE
Remove MimeKit dependency and add TextFormat enum

### DIFF
--- a/TwitPoster.Shared/TwitPoster.Shared/Contracts/EmailCommand.cs
+++ b/TwitPoster.Shared/TwitPoster.Shared/Contracts/EmailCommand.cs
@@ -1,7 +1,22 @@
-﻿using MimeKit.Text;
+﻿namespace TwitPoster.Shared.Contracts;
 
-namespace TwitPoster.Shared.Contracts;
-
+public enum TextFormat
+{
+    /// <summary>The plain text format.</summary>
+    Plain = 0,
+    /// <summary>An alias for the plain text format.</summary>
+    Text = 0,
+    /// <summary>The flowed text format (as described in rfc3676).</summary>
+    Flowed = 1,
+    /// <summary>The HTML text format.</summary>
+    Html = 2,
+    /// <summary>The enriched text format.</summary>
+    Enriched = 3,
+    /// <summary>The compressed rich text format.</summary>
+    CompressedRichText = 4,
+    /// <summary>The rich text format.</summary>
+    RichText = 5,
+}
 public sealed class EmailCommand
 {
     public string To { get; set; }

--- a/TwitPoster.Shared/TwitPoster.Shared/TwitPoster.Shared.csproj
+++ b/TwitPoster.Shared/TwitPoster.Shared/TwitPoster.Shared.csproj
@@ -11,9 +11,6 @@
         <Company>Wallyrion</Company>
     </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="MimeKit" Version="4.1.0" />
-    </ItemGroup>
 
     <PropertyGroup>
         <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
The MimeKit package reference in TwitPoster.Shared.csproj file was removed as it was unnecessary and replaced with an in-built TextFormat enum in the EmailCommand.cs file. This was