### PR TITLE
Update Twitposter.Shared packages and email TextPart format

### DIFF
--- a/TwitPoster.EmailSender/src/TwitPoster.EmailSender/Services/EmailSender.cs
+++ b/TwitPoster.EmailSender/src/TwitPoster.EmailSender/Services/EmailSender.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using MimeKit;
 using MimeKit.Text;
 using TwitPoster.Shared.Contracts;
+using TextFormat = MimeKit.Text.TextFormat;
 
 namespace TwitPoster.EmailSender.Services;
 
@@ -23,7 +24,9 @@ public class EmailService : IEmailService
         email.From.Add(MailboxAddress.Parse(_mailOptions.SendEmailFrom));
         email.To.Add(MailboxAddress.Parse(command.To));
         email.Subject = command.Subject;
-        email.Body = new TextPart(TextFormat.Plain) { Text = command.Body };
+        var textFormat = command.Format.ToString();
+        var textFormatType = Enum.Parse<TextFormat>(textFormat);
+        email.Body = new TextPart(textFormatType) { Text = command.Body };
 
         using var smtp = new SmtpClient();
         await smtp.ConnectAsync(_mailOptions.Host, _mailOptions.Port, SecureSocketOptions.StartTls);

--- a/TwitPoster.EmailSender/src/TwitPoster.EmailSender/TwitPoster.EmailSender.csproj
+++ b/TwitPoster.EmailSender/src/TwitPoster.EmailSender/TwitPoster.EmailSender.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MailKit" Version="4.1.0" />
+        <PackageReference Include="MailKit" Version="4.2.0" />
         <PackageReference Include="MassTransit" Version="8.1.1-develop.1522" />
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.1-develop.1522" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0-preview.7.23375.9" />
@@ -18,6 +18,6 @@
         <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
         <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.3-dev-00262" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <PackageReference Include="Twitposter.Shared" Version="1.0.4" />
+        <PackageReference Include="Twitposter.Shared" Version="2.2.1" />
     </ItemGroup>
 </Project>

--- a/TwitPoster/src/TwitPoster.BLL/Authentication/AuthService.cs
+++ b/TwitPoster/src/TwitPoster.BLL/Authentication/AuthService.cs
@@ -1,7 +1,6 @@
 ﻿using LanguageExt.Common;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
-using MimeKit.Text;
 using TwitPoster.BLL.Exceptions;
 using TwitPoster.BLL.Interfaces;
 using TwitPoster.DAL;

--- a/TwitPoster/src/TwitPoster.BLL/TwitPoster.BLL.csproj
+++ b/TwitPoster/src/TwitPoster.BLL/TwitPoster.BLL.csproj
@@ -12,11 +12,10 @@
 
     <ItemGroup>
       <PackageReference Include="LanguageExt.Core" Version="4.4.4" />
-      <PackageReference Include="MailKit" Version="4.2.0" />
       <PackageReference Include="Mapster" Version="7.4.0-pre06" />
       <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1-pre02" />
       <PackageReference Include="MassTransit.Abstractions" Version="8.1.1-develop.1522" />
-      <PackageReference Include="Twitposter.Shared" Version="1.0.4" />
+      <PackageReference Include="Twitposter.Shared" Version="2.2.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgraded MailKit from version 4.1.0 to 4.2.0 and Twitposter.Shared from 1.0.4 to 2.2.1 to leverage new features and improvements from these newer