### PR TITLE
Disable TestBackgroundService in startup configuration

### DIFF
--- a/TwitPoster/src/TwitPoster.Web/Program.cs
+++ b/TwitPoster/src/TwitPoster.Web/Program.cs
@@ -59,15 +59,13 @@ builder.Services
             .AllowCredentials();
     }))
     .AddHostedService<MigrationHostedService>()
-    .AddHostedService<TestBackgroundService>()
+    //.AddHostedService<TestBackgroundService>()
     
     .AddStackExchangeRedisCache(x =>
     {
         x.Configuration = builder.Configuration.GetConnectionString("Redis")!;
     })
     ;
-
-
 
 var app = builder.Build();
 


### PR DESCRIPTION
The TestBackgroundService was commented out from the startup.cs file. This service was initially used for testing purposes and is no longer required in the production environment.