### PR TITLE
Play with github actions and separate envs

### DIFF
--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -26,8 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.0'
-          dotnet-quality: 'preview'
+          dotnet-version: 8.0.0-preview.6
       - name: Restore dependencies - TwitPoster
         run: dotnet restore ./TwitPoster
       - name: Build - TwitPoster

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -12,33 +12,30 @@ on:
       - "TwitPoster/**"
       - ".github/workflows/TwitPoster.yml"
 
-
 env:
   AZURE_WEBAPP_NAME: "twitposter"
   AZURE_WEBAPP_PACKAGE_PATH: "./publish"
 
 jobs:
   build-and-deploy:
-
     runs-on: ubuntu-latest
 
     steps:
       - name: Identify Branch
         id: branch_name
-        run: echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
+        run: echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
 
       - name: Set environment dynamically
         id: set_env
         run: |
-          BRANCH=${{ steps.branch_name.outputs.branch }}
-          if [[ "$BRANCH" == "master" ]]; then
-            echo "::set-output name=env::prod"
-          elif [[ "$BRANCH" == "dev" ]]; then
-            echo "::set-output name=env::development"
+          if [[ "${BRANCH}" == "master" ]]; then
+            echo "ENV=prod" >> $GITHUB_ENV
+          elif [[ "${BRANCH}" == "dev" ]]; then
+            echo "ENV=development" >> $GITHUB_ENV
           else
-            echo "::set-output name=env::other-environment"
+            echo "ENV=other-environment" >> $GITHUB_ENV
           fi
-        
+
       - uses: actions/checkout@v3
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
@@ -53,7 +50,7 @@ jobs:
 
       - name: publish
         run: dotnet publish ./TwitPoster/src/TwitPoster.Web/TwitPoster.Web.csproj -c Release --no-build -o ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-        
+
       - name: Deployment to twitposter
         uses: azure/webapps-deploy@v2
         with:

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.0-preview.7.23375.6
+          dotnet-version: 8.0.0-preview.6.23329.7
       - name: Restore dependencies - TwitPoster
         run: dotnet restore ./TwitPoster
       - name: Build - TwitPoster

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.0-preview.6.23329.7
+          dotnet-version: '8.0.x'
+          dotnet-quality: 'preview'
       - name: Restore dependencies - TwitPoster
         run: dotnet restore ./TwitPoster
       - name: Build - TwitPoster

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -26,8 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '8.x'
       - name: Restore dependencies - TwitPoster
         run: dotnet restore ./TwitPoster
       - name: Build - TwitPoster
@@ -44,11 +43,3 @@ jobs:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-      - name: Deployment to twitposter for guide
-        uses: azure/webapps-deploy@v2
-        with:
-          app-name: twitposter-for-guide
-          publish-profile: ${{ secrets.AZURE_FOR_GUIDE_WEBAPP_PUBLISH_PROFILE }}
-          package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-        
-        

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build-and-deploy:
-    environment: 'prod'
+    environment: 'dev'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -18,7 +18,7 @@ env:
   AZURE_WEBAPP_PACKAGE_PATH: "./publish"
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
 
     steps:
@@ -37,12 +37,17 @@ jobs:
       - name: publish
         run: dotnet publish ./TwitPoster/src/TwitPoster.Web/TwitPoster.Web.csproj -c Release --no-build -o ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
         
-      - name: Deployment
+      - name: Deployment to twitposter
         uses: azure/webapps-deploy@v2
-        if: github.ref == 'refs/heads/master'
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+      - name: Deployment to twitposter for guide
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: twitposter-for-guide
+          publish-profile: ${{ secrets.AZURE_FOR_GUIDE_WEBAPP_PUBLISH_PROFILE }}
           package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
         
         

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.0-preview.6
+          dotnet-version: '8.0.x'
+          dotnet-quality: 'preview'
       - name: Restore dependencies - TwitPoster
         run: dotnet restore ./TwitPoster
       - name: Build - TwitPoster

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -13,6 +13,7 @@ on:
       - ".github/workflows/TwitPoster.yml"
   
   workflow_dispatch:
+    branches: ["azure/investigate-version-problem"]
     inputs:
       environment:
         description: 'Target environment'

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -2,40 +2,25 @@ name: Build & Test - TwitPoster
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "dev"]
     paths:
       - "TwitPoster/**"
       - ".github/workflows/TwitPoster.yml"
   pull_request:
-    branches: ["master"]
+    branches: ["master", "dev"]
     paths:
       - "TwitPoster/**"
       - ".github/workflows/TwitPoster.yml"
 
 env:
-  AZURE_WEBAPP_NAME: "twitposter"
   AZURE_WEBAPP_PACKAGE_PATH: "./publish"
 
 jobs:
-  build-and-deploy:
+
+  build:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Identify Branch
-        id: branch_name
-        run: echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-
-      - name: Set environment dynamically
-        id: set_env
-        run: |
-          if [[ "${BRANCH}" == "master" ]]; then
-            echo "ENV=prod" >> $GITHUB_ENV
-          elif [[ "${BRANCH}" == "dev" ]]; then
-            echo "ENV=development" >> $GITHUB_ENV
-          else
-            echo "ENV=other-environment" >> $GITHUB_ENV
-          fi
-
       - uses: actions/checkout@v3
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
@@ -47,13 +32,30 @@ jobs:
         run: dotnet build --no-restore ./TwitPoster -c Release
       - name: Test - TwitPoster
         run: dotnet test --no-build --verbosity normal ./TwitPoster -c Release
-
       - name: publish
         run: dotnet publish ./TwitPoster/src/TwitPoster.Web/TwitPoster.Web.csproj -c Release --no-build -o ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: TwitPoster
+          path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+  deploy:
+    needs: build
+    environment: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && 'prod' || 'dev' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: TwitPoster
+          path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
       - name: Deployment to twitposter
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME_TWITPOSTER }}
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE_TWITPOSTER }}
           package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -2,26 +2,44 @@ name: Build & Test - TwitPoster
 
 on:
   push:
-    branches: ["master", "dev"]
+    branches: ["master"]
     paths:
       - "TwitPoster/**"
       - ".github/workflows/TwitPoster.yml"
   pull_request:
-    branches: ["master", "dev"]
+    branches: ["master"]
     paths:
       - "TwitPoster/**"
       - ".github/workflows/TwitPoster.yml"
+
 
 env:
   AZURE_WEBAPP_NAME: "twitposter"
   AZURE_WEBAPP_PACKAGE_PATH: "./publish"
 
 jobs:
+  build-and-deploy:
 
-  build:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Identify Branch
+        id: branch_name
+        run: echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
+
+      - name: Set environment dynamically
+        id: set_env
+        run: |
+          BRANCH=${{ steps.branch_name.outputs.branch }}
+          if [[ "$BRANCH" == "master" ]]; then
+            echo "::set-output name=env::prod"
+          elif [[ "$BRANCH" == "dev" ]]; then
+            echo "::set-output name=env::development"
+          else
+            echo "::set-output name=env::other-environment"
+          fi
+        
+        
       - uses: actions/checkout@v3
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
@@ -33,30 +51,13 @@ jobs:
         run: dotnet build --no-restore ./TwitPoster -c Release
       - name: Test - TwitPoster
         run: dotnet test --no-build --verbosity normal ./TwitPoster -c Release
+
       - name: publish
         run: dotnet publish ./TwitPoster/src/TwitPoster.Web/TwitPoster.Web.csproj -c Release --no-build -o ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: TwitPoster
-          path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-
-  deploy:
-    needs: build
-    environment: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && 'prod' || 'dev' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download Artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: TwitPoster
-          path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-
+        
       - name: Deployment to twitposter
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          app-name: ${{ env.AZURE_WEBAPP_NAME_TWITPOSTER }}
           publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE_TWITPOSTER }}
           package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '8.0.0'
           dotnet-quality: 'preview'
       - name: Restore dependencies - TwitPoster
         run: dotnet restore ./TwitPoster

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -13,13 +13,10 @@ on:
       - ".github/workflows/TwitPoster.yml"
   
   workflow_dispatch:
-    branches: ["azure/investigate-version-problem"]
-    inputs:
-      environment:
-        description: 'Target environment'
-        required: false
-        default: 'prod'
-
+    branches: ["master", "azure/investigate-version-problem"]
+    paths:
+      - "TwitPoster/**"
+      - ".github/workflows/TwitPoster.yml"
 env:
   AZURE_WEBAPP_PACKAGE_PATH: "./publish"
 
@@ -71,7 +68,7 @@ jobs:
   deploy_prod:
     needs: build
     if: github.event_name == 'workflow_dispatch'
-    environment: ${{ github.event.inputs.environment }}
+    environment: 'prod'
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifact

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -50,7 +50,6 @@ jobs:
 
   deploy_dev:
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     environment: 'dev'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -11,6 +11,13 @@ on:
     paths:
       - "TwitPoster/**"
       - ".github/workflows/TwitPoster.yml"
+  
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: false
+        default: 'prod'
 
 env:
   AZURE_WEBAPP_PACKAGE_PATH: "./publish"
@@ -36,19 +43,39 @@ jobs:
         run: dotnet publish ./TwitPoster/src/TwitPoster.Web/TwitPoster.Web.csproj -c Release --no-build -o ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: TwitPoster
           path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
-  deploy:
+  deploy_dev:
     needs: build
-    environment: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && 'prod' || 'dev' }}
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    environment: 'dev'
     runs-on: ubuntu-latest
 
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
+        with:
+          name: TwitPoster
+          path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+      - name: Deployment to twitposter
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE_TWITPOSTER }}
+          package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+          
+  deploy_prod:
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    environment: ${{ github.event.inputs.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v3
         with:
           name: TwitPoster
           path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -39,7 +39,6 @@ jobs:
             echo "::set-output name=env::other-environment"
           fi
         
-        
       - uses: actions/checkout@v3
       - name: Setup .NET
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 8.0.0-preview.7.23375.6
       - name: Restore dependencies - TwitPoster
         run: dotnet restore ./TwitPoster
       - name: Build - TwitPoster

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -38,6 +38,7 @@ jobs:
         run: dotnet publish ./TwitPoster/src/TwitPoster.Web/TwitPoster.Web.csproj -c Release --no-build -o ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
         
       - name: Deployment to twitposter
+        if: github.ref == 'refs/heads/master'
         uses: azure/webapps-deploy@v2
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -19,6 +19,8 @@ env:
 
 jobs:
   build-and-deploy:
+    environment: 'prod'
+
     runs-on: ubuntu-latest
 
     steps:
@@ -38,9 +40,8 @@ jobs:
         run: dotnet publish ./TwitPoster/src/TwitPoster.Web/TwitPoster.Web.csproj -c Release --no-build -o ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
         
       - name: Deployment to twitposter
-        if: github.ref == 'refs/heads/master'
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME }}
-          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          app-name: ${{ env.AZURE_WEBAPP_NAME_TWITPOSTER }}
+          publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE_TWITPOSTER }}
           package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}

--- a/.github/workflows/TwitPoster.yml
+++ b/.github/workflows/TwitPoster.yml
@@ -2,25 +2,23 @@ name: Build & Test - TwitPoster
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "dev"]
     paths:
       - "TwitPoster/**"
       - ".github/workflows/TwitPoster.yml"
   pull_request:
-    branches: ["master"]
+    branches: ["master", "dev"]
     paths:
       - "TwitPoster/**"
       - ".github/workflows/TwitPoster.yml"
-
 
 env:
   AZURE_WEBAPP_NAME: "twitposter"
   AZURE_WEBAPP_PACKAGE_PATH: "./publish"
 
 jobs:
-  build-and-deploy:
-    environment: 'dev'
 
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -35,13 +33,30 @@ jobs:
         run: dotnet build --no-restore ./TwitPoster -c Release
       - name: Test - TwitPoster
         run: dotnet test --no-build --verbosity normal ./TwitPoster -c Release
-
       - name: publish
         run: dotnet publish ./TwitPoster/src/TwitPoster.Web/TwitPoster.Web.csproj -c Release --no-build -o ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-        
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: TwitPoster
+          path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+  deploy:
+    needs: build
+    environment: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && 'prod' || 'dev' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: TwitPoster
+          path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
       - name: Deployment to twitposter
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME_TWITPOSTER }}
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE_TWITPOSTER }}
           package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}


### PR DESCRIPTION
In the TwitPoster GitHub Workflow, the `build` job is renamed to `build-and-deploy` for clarity and the