### PR TITLE
Switch messaging service to Azure Service Bus

### DIFF
--- a/.github/workflows/TwitPoster.build-deploy.yml
+++ b/.github/workflows/TwitPoster.build-deploy.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Deployment to twitposter
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          app-name: ${{ env.AZURE_WEBAPP_NAME_TWITPOSTER }}
           publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE_TWITPOSTER }}
           package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
   
@@ -70,6 +70,6 @@ jobs:
       - name: Deployment to twitposter
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          app-name: ${{ env.AZURE_WEBAPP_NAME_TWITPOSTER }}
           publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE_TWITPOSTER }}
           package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}

--- a/.github/workflows/TwitPoster.build-deploy.yml
+++ b/.github/workflows/TwitPoster.build-deploy.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - "TwitPoster/**"
       - ".github/workflows/TwitPoster.yml"
+  workflow_dispatch:
+
 
 env:
   AZURE_WEBAPP_PACKAGE_PATH: "./publish"

--- a/TwitPoster.EmailSender/src/TwitPoster.EmailSender/Program.cs
+++ b/TwitPoster.EmailSender/src/TwitPoster.EmailSender/Program.cs
@@ -2,7 +2,9 @@ using System.Reflection;
 using MassTransit;
 using Serilog;
 using TwitPoster.EmailSender;
+using TwitPoster.EmailSender.Consumer;
 using TwitPoster.EmailSender.Services;
+using TwitPoster.Shared.Contracts;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Host.UseSerilog((ctx, lc) => lc
@@ -14,7 +16,7 @@ var mailOptions = builder.Configuration.GetRequiredSection("Mail");
 
 builder.Services
     .Configure<MailOptions>(mailOptions)
-    .Configure<RabbitMqTransportOptions>(rabbitMqConfig)
+    //.Configure<RabbitMqTransportOptions>(rabbitMqConfig)
     .AddScoped<IEmailService, EmailService>()
     
     .AddMassTransit(x =>
@@ -22,19 +24,21 @@ builder.Services
         var entryAssembly = Assembly.GetExecutingAssembly();
         x.AddConsumers(entryAssembly);
 
-        if (builder.Environment.IsDevelopment())
+        /*if (builder.Environment.IsDevelopment())
         {
             x.UsingRabbitMq((context, cfg) => cfg.ConfigureEndpoints(context));
-        }
-        else
-        {
-            x.UsingAzureServiceBus((context, cfg) =>
-            {
-                cfg.Host(builder.Configuration.GetConnectionString("ServiceBus"));
+        }{*/
         
-                cfg.ConfigureEndpoints(context);
-            });    
-        }
+        x.UsingAzureServiceBus((context, cfg) =>
+        {
+            cfg.Host(builder.Configuration.GetConnectionString("ServiceBus"));
+            
+            cfg.UseServiceBusMessageScheduler();
+            cfg.SubscriptionEndpoint<EmailCommand>($"EmailSenderSubscription" , configurator =>
+            {
+                configurator.ConfigureConsumer<EmailCommandConsumer>(context);
+            });
+        });      
     });
 
 var app = builder.Build();

--- a/TwitPoster/src/TwitPoster.Web/Program.cs
+++ b/TwitPoster/src/TwitPoster.Web/Program.cs
@@ -6,6 +6,7 @@ using TwitPoster.BLL.Interfaces;
 using TwitPoster.BLL.Options;
 using TwitPoster.BLL.Services;
 using TwitPoster.DAL;
+using TwitPoster.Shared.Contracts;
 using TwitPoster.Web;
 using TwitPoster.Web.Common;
 using TwitPoster.Web.Extensions;
@@ -42,14 +43,19 @@ builder.Services
     .AddScoped<IAuthService, AuthService>()
     .AddSingleton<IJwtTokenGenerator, JwtTokenGenerator>()
 
-    .Configure<RabbitMqTransportOptions>(rabbitMqConfig)
+    //.Configure<RabbitMqTransportOptions>(rabbitMqConfig)
     
     .AddMassTransit(x =>
     {
-        if (builder.Environment.IsDevelopment())
+        /*if (builder.Environment.IsDevelopment())
             x.UsingRabbitMq();
-        else
-            x.UsingAzureServiceBus((_, cfg) => cfg.Host(builder.Configuration.GetConnectionString("ServiceBus")!));
+        else*/
+        x.UsingAzureServiceBus((_, cfg) =>
+        {
+            cfg.UseServiceBusMessageScheduler();
+            
+            cfg.Host(builder.Configuration.GetConnectionString("ServiceBus")!);
+        });
     })
     .AddCors(options => options.AddPolicy(WebConstants.Cors.DefaultPolicy, o =>
     {


### PR DESCRIPTION
The messaging service is switched from local RabbitMQ service to Azure Service Bus. This is done to unify communication between applications and to make use of Azure’s powerful services for production environments. Changes made include the addition of Azure Bus configuration and removal of RabbitMQ configuration. Additionally, MailOptions, IServiceBusMessageScheduler and EmailCommandConsumer are added to accommodate for these changes.