### PR TITLE
Add repository_dispatch event to TwitPoster workflow

### DIFF
--- a/.github/workflows/TwitPoster.build-deploy.yml
+++ b/.github/workflows/TwitPoster.build-deploy.yml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/build-deploy.yml"
       - ".github/workflows/build.yml"
 
+  repository_dispatch:
 
 env:
   AZURE_WEBAPP_PACKAGE_PATH: "./publish"

--- a/.github/workflows/TwitPoster.build-deploy.yml
+++ b/.github/workflows/TwitPoster.build-deploy.yml
@@ -5,8 +5,8 @@ on:
     branches: ["master"]
     paths:
       - "TwitPoster/**"
-      - ".github/workflows/build-deploy.yml"
-      - ".github/workflows/build.yml"
+      - ".github/workflows/TwitPoster.build-deploy.yml"
+      - ".github/workflows/TwitPoster.build.yml"
 
   repository_dispatch:
 

--- a/.github/workflows/TwitPoster.build.yml
+++ b/.github/workflows/TwitPoster.build.yml
@@ -5,8 +5,8 @@ on:
     branches: ["master"]
     paths:
       - "TwitPoster/**"
-      - ".github/workflows/build-deploy.yml"
-      - ".github/workflows/build.yml"
+      - ".github/workflows/TwitPoster.build-deploy.yml"
+      - ".github/workflows/TwitPoster.build.yml"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,4 +24,6 @@ jobs:
         run: dotnet build --no-restore ./TwitPoster -c Release
         
       - name: Test - TwitPoster
+        env:
+          ASPNETCORE_ENVIRONMENT: Production
         run: dotnet test --no-build --verbosity normal ./TwitPoster -c Release


### PR DESCRIPTION
This commit adds a "repository_dispatch" event trigger to the TwitPoster github workflow. This is to allow manual triggering of the workflow via github's API, providing greater control over deployment processes.