### PR TITLE
Add Location functionality to the TwitPoster app

### DIFF
--- a/TwitPoster/src/TwitPoster.BLL/DTOs/Location/Country.cs
+++ b/TwitPoster/src/TwitPoster.BLL/DTOs/Location/Country.cs
@@ -1,0 +1,3 @@
+﻿namespace TwitPoster.BLL.DTOs.Location;
+
+public record Country(string Name, string Code, string UnicodeFlag);

--- a/TwitPoster/src/TwitPoster.BLL/External/Location/CountriesResponse.cs
+++ b/TwitPoster/src/TwitPoster.BLL/External/Location/CountriesResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace TwitPoster.BLL.External.Location;
+
+public record CountriesResponse (bool Error, string Msg, List<CountryResponseItem> Data);
+public record StatesResponse (bool Error, string Msg, StatesResponseItem Data);
+public record CitiesResponse (bool Error, string Msg, List<string> Data);
+public record StatesResponseItem(string Name, string Iso2, string Iso3, List<StateResponseItem> States);
+public record StateResponseItem(string Name, string State_Code);
+public record CountryResponseItem (string Name, string Iso2, string Iso3, string UnicodeFlag);

--- a/TwitPoster/src/TwitPoster.BLL/External/Location/ILocationClient.cs
+++ b/TwitPoster/src/TwitPoster.BLL/External/Location/ILocationClient.cs
@@ -1,6 +1,4 @@
-﻿using System.Net.Http.Json;
-
-namespace TwitPoster.BLL.External.Location;
+﻿namespace TwitPoster.BLL.External.Location;
 
 public interface ILocationClient
 {
@@ -8,43 +6,3 @@ public interface ILocationClient
     Task<StatesResponse> GetStates(string countryName, CancellationToken cancellationToken = default);
     Task<CitiesResponse> GetCities(string countryName, string stateName, CancellationToken cancellationToken = default);
 }
-
-
-public class LocationClient : ILocationClient
-{
-    private readonly HttpClient _httpClient;
-    
-    public LocationClient(HttpClient httpClient)
-    {
-        _httpClient = httpClient;
-    }
-    
-    public async Task<CountriesResponse> GetCountries(CancellationToken cancellationToken = default)
-    {
-        var response = await _httpClient.GetAsync("api/v0.1/countries/flag/unicode", cancellationToken);
-        response.EnsureSuccessStatusCode();
-        var content = await response.Content.ReadFromJsonAsync<CountriesResponse>(cancellationToken);
-
-        return content!;
-    }
-
-    public async Task<StatesResponse> GetStates(string countryName, CancellationToken cancellationToken = default)
-    {
-        var response = await _httpClient.PostAsJsonAsync("api/v0.1/countries/states", new { country = countryName }, cancellationToken);
-        response.EnsureSuccessStatusCode();
-        var content = await response.Content.ReadFromJsonAsync<StatesResponse>(cancellationToken);
-
-        return content!;
-    }
-
-    public async Task<CitiesResponse> GetCities(string countryName, string stateName, CancellationToken cancellationToken = default)
-    {
-        var response = await _httpClient.PostAsJsonAsync("api/v0.1/countries/state/cities", new { country = countryName, state = stateName }, cancellationToken);
-        response.EnsureSuccessStatusCode();
-        var content = await response.Content.ReadFromJsonAsync<CitiesResponse>(cancellationToken);
-
-        return content!;
-    }
-}
-
-

--- a/TwitPoster/src/TwitPoster.BLL/External/Location/ILocationClient.cs
+++ b/TwitPoster/src/TwitPoster.BLL/External/Location/ILocationClient.cs
@@ -1,0 +1,50 @@
+﻿using System.Net.Http.Json;
+
+namespace TwitPoster.BLL.External.Location;
+
+public interface ILocationClient
+{
+    Task<CountriesResponse> GetCountries(CancellationToken cancellationToken = default);
+    Task<StatesResponse> GetStates(string countryName, CancellationToken cancellationToken = default);
+    Task<CitiesResponse> GetCities(string countryName, string stateName, CancellationToken cancellationToken = default);
+}
+
+
+public class LocationClient : ILocationClient
+{
+    private readonly HttpClient _httpClient;
+    
+    public LocationClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+    
+    public async Task<CountriesResponse> GetCountries(CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync("api/v0.1/countries/flag/unicode", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadFromJsonAsync<CountriesResponse>(cancellationToken);
+
+        return content!;
+    }
+
+    public async Task<StatesResponse> GetStates(string countryName, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PostAsJsonAsync("api/v0.1/countries/states", new { country = countryName }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadFromJsonAsync<StatesResponse>(cancellationToken);
+
+        return content!;
+    }
+
+    public async Task<CitiesResponse> GetCities(string countryName, string stateName, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PostAsJsonAsync("api/v0.1/countries/state/cities", new { country = countryName, state = stateName }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadFromJsonAsync<CitiesResponse>(cancellationToken);
+
+        return content!;
+    }
+}
+
+

--- a/TwitPoster/src/TwitPoster.BLL/External/Location/LocationClient.cs
+++ b/TwitPoster/src/TwitPoster.BLL/External/Location/LocationClient.cs
@@ -1,0 +1,40 @@
+﻿using System.Net.Http.Json;
+
+namespace TwitPoster.BLL.External.Location;
+
+public class LocationClient : ILocationClient
+{
+    private readonly HttpClient _httpClient;
+    
+    public LocationClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+    
+    public async Task<CountriesResponse> GetCountries(CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync("api/v0.1/countries/flag/unicode", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadFromJsonAsync<CountriesResponse>(cancellationToken);
+
+        return content!;
+    }
+
+    public async Task<StatesResponse> GetStates(string countryName, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PostAsJsonAsync("api/v0.1/countries/states", new { country = countryName }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadFromJsonAsync<StatesResponse>(cancellationToken);
+
+        return content!;
+    }
+
+    public async Task<CitiesResponse> GetCities(string countryName, string stateName, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PostAsJsonAsync("api/v0.1/countries/state/cities", new { country = countryName, state = stateName }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadFromJsonAsync<CitiesResponse>(cancellationToken);
+
+        return content!;
+    }
+}

--- a/TwitPoster/src/TwitPoster.BLL/Interfaces/ICacheService.cs
+++ b/TwitPoster/src/TwitPoster.BLL/Interfaces/ICacheService.cs
@@ -1,0 +1,6 @@
+﻿namespace TwitPoster.BLL.Interfaces;
+
+public interface ICacheService
+{
+    public Task<T?> GetFromCacheOrCreate<T>(string key, Func<Task<T>> factory, TimeSpan? expirationTime = null, CancellationToken cancellationToken = default);
+}

--- a/TwitPoster/src/TwitPoster.BLL/Interfaces/ILocationService.cs
+++ b/TwitPoster/src/TwitPoster.BLL/Interfaces/ILocationService.cs
@@ -1,0 +1,10 @@
+﻿using TwitPoster.BLL.DTOs.Location;
+
+namespace TwitPoster.BLL.Interfaces;
+
+public interface ILocationService
+{
+    Task<IReadOnlyList<Country>> GetCountries (CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<string>> GetStates(string countryName, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<string>> GetCities (string countryName, string stateName, CancellationToken cancellationToken = default);
+}

--- a/TwitPoster/src/TwitPoster.BLL/Mappers/LocationConfig.cs
+++ b/TwitPoster/src/TwitPoster.BLL/Mappers/LocationConfig.cs
@@ -1,0 +1,20 @@
+﻿using Mapster;
+using TwitPoster.BLL.DTOs.Location;
+using TwitPoster.BLL.External.Location;
+
+namespace TwitPoster.BLL.Mappers;
+
+public class LocationConfig : IRegister
+{
+    public void Register(TypeAdapterConfig config)
+    {
+        config.NewConfig<CountryResponseItem, Country>()
+            .Map(dest => dest.Code, src => src.Iso2)
+            .Map(dest => dest.UnicodeFlag, src => src.UnicodeFlag)
+            .Map(dest => dest.Name, src => src.Name);
+        
+        config.NewConfig<CountriesResponse, IReadOnlyList<Country>>()
+            .ConstructUsing(x => x.Data.Adapt<IReadOnlyList<Country>>())
+            ;
+    }
+}

--- a/TwitPoster/src/TwitPoster.BLL/Services/DistributedCacheService.cs
+++ b/TwitPoster/src/TwitPoster.BLL/Services/DistributedCacheService.cs
@@ -1,0 +1,37 @@
+﻿using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace TwitPoster.BLL.Services;
+
+public class DistributedCacheService : ICacheService
+{
+    private readonly IDistributedCache _distributedCache;
+
+    public DistributedCacheService(IDistributedCache distributedCache)
+    {
+        _distributedCache = distributedCache;
+    }
+    
+    public async Task<T?> GetFromCacheOrCreate<T>(string key, Func<Task<T>> factory, TimeSpan? expirationTime = null, CancellationToken cancellationToken = default)
+    {
+        expirationTime ??= TimeSpan.FromMinutes(10);
+        
+        var fromCache = await _distributedCache.GetStringAsync(key, cancellationToken);
+
+        if (fromCache == null)
+        {
+            var res = await factory();
+            
+            await _distributedCache.SetStringAsync(key, JsonSerializer.Serialize(res), new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = expirationTime
+            }, cancellationToken);
+
+            return res;
+        }
+
+        var deserialized = JsonSerializer.Deserialize<T>(fromCache);
+
+        return deserialized;
+    }
+}

--- a/TwitPoster/src/TwitPoster.BLL/Services/DistributedCacheService.cs
+++ b/TwitPoster/src/TwitPoster.BLL/Services/DistributedCacheService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using Microsoft.Extensions.Caching.Distributed;
+using TwitPoster.BLL.Interfaces;
 
 namespace TwitPoster.BLL.Services;
 

--- a/TwitPoster/src/TwitPoster.BLL/Services/LocationService.cs
+++ b/TwitPoster/src/TwitPoster.BLL/Services/LocationService.cs
@@ -66,8 +66,3 @@ public class LocationService : ILocationService
         }
     }
 }
-
-public interface ICacheService
-{
-    public Task<T?> GetFromCacheOrCreate<T>(string key, Func<Task<T>> factory, TimeSpan? expirationTime = null, CancellationToken cancellationToken = default);
-}

--- a/TwitPoster/src/TwitPoster.BLL/Services/LocationService.cs
+++ b/TwitPoster/src/TwitPoster.BLL/Services/LocationService.cs
@@ -1,0 +1,135 @@
+﻿using System.Net;
+using System.Text.Json;
+using Mapster;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using TwitPoster.BLL.DTOs.Location;
+using TwitPoster.BLL.External.Location;
+using TwitPoster.BLL.Interfaces;
+
+namespace TwitPoster.BLL.Services;
+
+public class LocationService : ILocationService
+{
+    private readonly ILocationClient _locationClient;
+    private readonly ICacheService _cacheService;
+
+    public LocationService(ILocationClient locationClient, ICacheService cacheService)
+    {
+        _locationClient = locationClient;
+        _cacheService = cacheService;
+    }
+
+    public async Task<IReadOnlyList<Country>> GetCountries(CancellationToken cancellationToken = default)
+    {
+        var res = await GetFromCacheOrCreate<Country>("countries", async () =>
+        {
+            var result = await _locationClient.GetCountries(cancellationToken);
+
+            return result.Data.Adapt<IReadOnlyList<Country>>().ToList();
+        });
+        
+        return res;
+    }
+
+    public async Task<IReadOnlyList<string>> GetStates(string countryName, CancellationToken cancellationToken = default)
+    {
+        return await GetFromCacheOrCreate<string>($"country-{countryName}-states", async () =>
+        {
+            var result = await _locationClient.GetStates(countryName, cancellationToken);
+            return result.Data.States.Select(x => x.Name).ToList();
+        });
+    }
+
+    public async Task<IReadOnlyList<string>> GetCities(string countryName, string stateName, CancellationToken cancellationToken = default)
+    {
+        var cities = await GetFromCacheOrCreate<string>($"country-{countryName}-state-{stateName}-cities", async () => 
+            (await _locationClient.GetCities(countryName, stateName, cancellationToken)).Data);
+
+        return cities;
+    }
+    
+    private async Task<IReadOnlyList<T>> GetFromCacheOrCreate<T>(string key, Func<Task<IReadOnlyList<T>>> factory)
+    {
+        try
+        {
+            var result = await _cacheService.GetFromCacheOrCreate<IReadOnlyList<T>>(key, async () =>
+            {
+                
+                return await factory();
+
+            });
+
+            return result!;
+
+        }
+        catch (HttpRequestException e) when(e.StatusCode == HttpStatusCode.NotFound)
+        {
+            return new List<T>();
+        }
+    }
+}
+
+public class MemoryCacheService : ICacheService
+{
+    private readonly IMemoryCache _memoryCache;
+
+    public MemoryCacheService(IMemoryCache memoryCache)
+    {
+        _memoryCache = memoryCache;
+    }
+    
+    public async Task<T?> GetFromCacheOrCreate<T>(string key, Func<Task<T>> factory, TimeSpan? expirationTime = null, CancellationToken cancellationToken = default)
+    {
+        expirationTime ??= TimeSpan.FromMinutes(10);
+        
+        var result = await _memoryCache.GetOrCreateAsync<T>(key, async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = expirationTime;
+            return await factory();
+        });
+
+        return result!;
+    }
+}
+
+
+public class DistributedCacheService : ICacheService
+{
+    private readonly IDistributedCache _distributedCache;
+
+    public DistributedCacheService(IDistributedCache distributedCache)
+    {
+        _distributedCache = distributedCache;
+    }
+    
+    public async Task<T?> GetFromCacheOrCreate<T>(string key, Func<Task<T>> factory, TimeSpan? expirationTime = null, CancellationToken cancellationToken = default)
+    {
+        expirationTime ??= TimeSpan.FromMinutes(10);
+        
+        var fromCache = await _distributedCache.GetStringAsync(key, cancellationToken);
+
+        if (fromCache == null)
+        {
+            var res = await factory();
+            
+            await _distributedCache.SetStringAsync(key, JsonSerializer.Serialize(res), new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = expirationTime
+            }, cancellationToken);
+
+            return res;
+        }
+
+        var deserialized = JsonSerializer.Deserialize<T>(fromCache);
+
+        return deserialized;
+    }
+}
+
+
+
+public interface ICacheService
+{
+    public Task<T?> GetFromCacheOrCreate<T>(string key, Func<Task<T>> factory, TimeSpan? expirationTime = null, CancellationToken cancellationToken = default);
+}

--- a/TwitPoster/src/TwitPoster.BLL/Services/MemoryCacheService.cs
+++ b/TwitPoster/src/TwitPoster.BLL/Services/MemoryCacheService.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+
+namespace TwitPoster.BLL.Services;
+
+public class MemoryCacheService : ICacheService
+{
+    private readonly IMemoryCache _memoryCache;
+
+    public MemoryCacheService(IMemoryCache memoryCache)
+    {
+        _memoryCache = memoryCache;
+    }
+    
+    public async Task<T?> GetFromCacheOrCreate<T>(string key, Func<Task<T>> factory, TimeSpan? expirationTime = null, CancellationToken cancellationToken = default)
+    {
+        expirationTime ??= TimeSpan.FromMinutes(10);
+        
+        var result = await _memoryCache.GetOrCreateAsync<T>(key, async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = expirationTime;
+            return await factory();
+        });
+
+        return result!;
+    }
+}

--- a/TwitPoster/src/TwitPoster.BLL/Services/MemoryCacheService.cs
+++ b/TwitPoster/src/TwitPoster.BLL/Services/MemoryCacheService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
+using TwitPoster.BLL.Interfaces;
 
 namespace TwitPoster.BLL.Services;
 

--- a/TwitPoster/src/TwitPoster.Web/Common/DependencyInjection/ServiceCollectionExtension.cs
+++ b/TwitPoster/src/TwitPoster.Web/Common/DependencyInjection/ServiceCollectionExtension.cs
@@ -1,4 +1,5 @@
-﻿using TwitPoster.BLL.Services;
+﻿using TwitPoster.BLL.Interfaces;
+using TwitPoster.BLL.Services;
 using TwitPoster.Web.Common.Options;
 
 namespace TwitPoster.Web.Common.DependencyInjection;

--- a/TwitPoster/src/TwitPoster.Web/Common/DependencyInjection/ServiceCollectionExtension.cs
+++ b/TwitPoster/src/TwitPoster.Web/Common/DependencyInjection/ServiceCollectionExtension.cs
@@ -1,0 +1,32 @@
+﻿using TwitPoster.BLL.Services;
+using TwitPoster.Web.Common.Options;
+
+namespace TwitPoster.Web.Common.DependencyInjection;
+
+public static class ServiceCollectionExtension
+{
+    public static IServiceCollection AddTwitPosterCaching(this IServiceCollection services, IConfigurationManager configuration)
+    {
+        var featuresConfig = configuration.GetRequiredSection("Features");
+        
+        var featuresOptions = featuresConfig.Get<FeatureOptions>()!;
+
+        if (featuresOptions.UseRedisCache)
+        {
+            services
+                .AddStackExchangeRedisCache(x =>
+                {
+                    x.Configuration = configuration.GetConnectionString("Redis")!;
+                })
+                .AddScoped<ICacheService, DistributedCacheService>();
+        }
+        else
+        {
+            services
+                .AddMemoryCache()
+                .AddScoped<ICacheService, MemoryCacheService>();
+        }
+
+        return services;
+    } 
+}

--- a/TwitPoster/src/TwitPoster.Web/Common/Options/FeatureOptions.cs
+++ b/TwitPoster/src/TwitPoster.Web/Common/Options/FeatureOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace TwitPoster.Web.Common.Options;
+
+public class FeatureOptions
+{
+    public bool UseRedisCache { get; set; }
+}

--- a/TwitPoster/src/TwitPoster.Web/Controllers/LocationController.cs
+++ b/TwitPoster/src/TwitPoster.Web/Controllers/LocationController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TwitPoster.BLL.DTOs.Location;
+using TwitPoster.BLL.Interfaces;
+
+namespace TwitPoster.Web.Controllers;
+
+[Route("[controller]")]
+[ApiController]
+[AllowAnonymous]
+public class LocationController : ControllerBase
+{
+    private readonly ILocationService _locationService;
+    
+    public LocationController(ILocationService locationService)
+    {
+        _locationService = locationService;
+    }
+
+    [HttpGet("countries")]
+    public async Task<IReadOnlyList<Country>> GetCountriesAsync(CancellationToken cancellationToken = default)
+    {
+        return await _locationService.GetCountries(cancellationToken);
+    }
+    
+    [HttpGet("{countryName}/states")]
+    public async Task<IReadOnlyList<string>> GetStates(string countryName, CancellationToken cancellationToken = default)
+    {
+        return await _locationService.GetStates(countryName, cancellationToken);
+    }
+    
+    [HttpGet("{countryName}/{stateName}/cities")]
+    public async Task<IReadOnlyList<string>> GetCountriesAsync(string countryName, string stateName, CancellationToken cancellationToken = default)
+    {
+        return await _locationService.GetCities(countryName, stateName, cancellationToken);
+    }
+}

--- a/TwitPoster/src/TwitPoster.Web/appsettings.Development.json
+++ b/TwitPoster/src/TwitPoster.Web/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "ConnectionStrings": {
     "DbConnection": "Server=.;Database=TwitPoster;Trusted_Connection=True;Encrypt=false;",
-    "Redis": "localhost:6379"
+    "Redis": "localhost:6380"
   },
   "RabbitMQ": {
     "Host": "localhost"

--- a/TwitPoster/src/TwitPoster.Web/appsettings.json
+++ b/TwitPoster/src/TwitPoster.Web/appsettings.json
@@ -11,6 +11,9 @@
     "Secret": "mysupersecret_secretkey!123_for#TwitPosterApp",
     "Expiration": "00:01:00:00"
   },
+  "Features": {
+    "UseRedisCache": "true"
+  },
   "RabbitMQ": {
     "Host": "my-rabbit"
   },


### PR DESCRIPTION
A new feature was added to the TwitPoster application that allows for the retrieval of location data (country, state, and city). New code includes the creation of a LocationController in the Web Project, a LocationService in the BLL Project, and the corresponding DTOs and interfaces. This functionality makes it possible for a user to retrieve location-specific data for their posts. Additionally, caching was implemented to minimize external requests and improve performance and efficiency. The application can now be configured to use either Redis or in-memory caching through the appsettings file.