### PR TITLE
Refactor service constructors to use less code

### DIFF
--- a/TwitPoster/src/TwitPoster.BLL/External/Location/LocationClient.cs
+++ b/TwitPoster/src/TwitPoster.BLL/External/Location/LocationClient.cs
@@ -2,18 +2,11 @@
 
 namespace TwitPoster.BLL.External.Location;
 
-public class LocationClient : ILocationClient
+public class LocationClient(HttpClient httpClient) : ILocationClient
 {
-    private readonly HttpClient _httpClient;
-    
-    public LocationClient(HttpClient httpClient)
-    {
-        _httpClient = httpClient;
-    }
-    
     public async Task<CountriesResponse> GetCountries(CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.GetAsync("api/v0.1/countries/flag/unicode", cancellationToken);
+        var response = await httpClient.GetAsync("api/v0.1/countries/flag/unicode", cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadFromJsonAsync<CountriesResponse>(cancellationToken);
 
@@ -22,7 +15,7 @@ public class LocationClient : ILocationClient
 
     public async Task<StatesResponse> GetStates(string countryName, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.PostAsJsonAsync("api/v0.1/countries/states", new { country = countryName }, cancellationToken);
+        var response = await httpClient.PostAsJsonAsync("api/v0.1/countries/states", new { country = countryName }, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadFromJsonAsync<StatesResponse>(cancellationToken);
 
@@ -31,7 +24,7 @@ public class LocationClient : ILocationClient
 
     public async Task<CitiesResponse> GetCities(string countryName, string stateName, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.PostAsJsonAsync("api/v0.1/countries/state/cities", new { country = countryName, state = stateName }, cancellationToken);
+        var response = await httpClient.PostAsJsonAsync("api/v0.1/countries/state/cities", new { country = countryName, state = stateName }, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadFromJsonAsync<CitiesResponse>(cancellationToken);
 

--- a/TwitPoster/src/TwitPoster.BLL/Services/MemoryCacheService.cs
+++ b/TwitPoster/src/TwitPoster.BLL/Services/MemoryCacheService.cs
@@ -3,20 +3,13 @@ using TwitPoster.BLL.Interfaces;
 
 namespace TwitPoster.BLL.Services;
 
-public class MemoryCacheService : ICacheService
+public class MemoryCacheService(IMemoryCache memoryCache) : ICacheService
 {
-    private readonly IMemoryCache _memoryCache;
-
-    public MemoryCacheService(IMemoryCache memoryCache)
-    {
-        _memoryCache = memoryCache;
-    }
-    
     public async Task<T?> GetFromCacheOrCreate<T>(string key, Func<Task<T?>> factory, TimeSpan? expirationTime = null, CancellationToken cancellationToken = default)
     {
         expirationTime ??= TimeSpan.FromMinutes(10);
 
-        var fromCache = _memoryCache.Get<T>(key);
+        var fromCache = memoryCache.Get<T>(key);
 
         if (fromCache is not null)
         {
@@ -30,7 +23,7 @@ public class MemoryCacheService : ICacheService
             return default;
         }
 
-        _memoryCache.Set(key, value, new MemoryCacheEntryOptions
+        memoryCache.Set(key, value, new MemoryCacheEntryOptions
         {
             AbsoluteExpirationRelativeToNow = expirationTime
         });

--- a/TwitPoster/src/TwitPoster.Web/Common/DependencyInjection/ServiceCollectionExtension.cs
+++ b/TwitPoster/src/TwitPoster.Web/Common/DependencyInjection/ServiceCollectionExtension.cs
@@ -8,7 +8,6 @@ public static class ServiceCollectionExtension
 {
     public static IServiceCollection AddTwitPosterCaching(this IServiceCollection services, IConfigurationManager configuration)
     {
-        
         services
             .AddMemoryCache();
             
@@ -21,7 +20,6 @@ public static class ServiceCollectionExtension
             .AddScoped<ICacheService, CacheService>()
             .AddKeyedScoped<ICacheService, DistributedCacheService>(DependencyInjectionKeys.DistributedCacheService)
             .AddKeyedScoped<ICacheService, MemoryCacheService>(DependencyInjectionKeys.MemoryService);
-
 
         return services;
     } 

--- a/TwitPoster/tests/TwitPoster.IntegrationTests/Post/LikePostTests.cs
+++ b/TwitPoster/tests/TwitPoster.IntegrationTests/Post/LikePostTests.cs
@@ -15,12 +15,13 @@ public class LikePostTests(IntegrationTestWebFactory factory) : BaseIntegrationT
         var postResponse = await ApiClient.PostAsJsonAsync("Posts", createPostRequest);
         postResponse.Should().Be200Ok();
         var post = await postResponse.Content.ReadFromJsonAsync<PostViewModel>();
+        post.Should().NotBeNull();
         
         var concurrentUsersCount = 100;
         var clients = await CreateConcurrentClients(concurrentUsersCount);
 
         var results = await Task.WhenAll(clients.Select(x => 
-            x.apiClient.PutAsync($"Posts/{post.Id}/like", null)));
+            x.apiClient.PutAsync($"Posts/{post!.Id}/like", null)));
 
         results.Should()
             .AllSatisfy(x => x.Should().Be200Ok());
@@ -39,18 +40,19 @@ public class LikePostTests(IntegrationTestWebFactory factory) : BaseIntegrationT
         var postResponse = await ApiClient.PostAsJsonAsync("Posts", createPostRequest);
         postResponse.Should().Be200Ok();
         var post = await postResponse.Content.ReadFromJsonAsync<PostViewModel>();
+        post.Should().NotBeNull();
         
         var concurrentUsersCount = 100;
         var clients = await CreateConcurrentClients(concurrentUsersCount);
 
         var resultsLike = await Task.WhenAll(clients.Select(x => 
-            x.apiClient.PutAsync($"Posts/{post.Id}/like", null)));
+            x.apiClient.PutAsync($"Posts/{post!.Id}/like", null)));
 
         resultsLike.Should()
             .AllSatisfy(x => x.Should().Be200Ok());
         
         var resultsUnlike = await Task.WhenAll(clients.Take(50).Select(x => 
-            x.apiClient.PutAsync($"Posts/{post.Id}/unlike", null)));
+            x.apiClient.PutAsync($"Posts/{post!.Id}/unlike", null)));
         
         resultsUnlike.Should()
             .AllSatisfy(x => x.Should().Be200Ok());


### PR DESCRIPTION
Services constructors were refactored to reduce redundant code. The changes involve simplification of constructors in `MemoryCacheService`, `LocationClient`, and `LocationService` by using injected parameters directly, instead of assigning them to private fields. This makes the code cleaner and more efficient.