### PR TITLE
Separate build and deploy workflows in Email Sender service

### DIFF
--- a/.github/workflows/TwitPoster.EmailSender.build.yml
+++ b/.github/workflows/TwitPoster.EmailSender.build.yml
@@ -6,7 +6,6 @@ on:
     branches: ["master"]
     paths:
       - "TwitPoster.EmailSender/**"
-      - ".github/workflows/TwitPoster.EmailSender.build-deploy.yml"
       - ".github/workflows/TwitPoster.EmailSender.build.yml"
 
 jobs:

--- a/.github/workflows/TwitPoster.EmailSender.deploy.yml
+++ b/.github/workflows/TwitPoster.EmailSender.deploy.yml
@@ -6,8 +6,7 @@ on:
     branches: ["master"]
     paths:
       - "TwitPoster.EmailSender/**"
-      - ".github/workflows/TwitPoster.EmailSender.build-deploy.yml"
-      - ".github/workflows/TwitPoster.EmailSender.build.yml"
+      - ".github/workflows/TwitPoster.EmailSender.deploy.yml"
 env:
   AZURE_WEBAPP_PACKAGE_PATH: "./publish"
 
@@ -37,29 +36,9 @@ jobs:
         with:
           name: TwitPoster.EmailSender
           path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-
-
-  deploy_dev:
-    needs: build
-    environment: 'dev'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: TwitPoster.EmailSender
-          path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-
-      - name: Deployment to twitposter
-        uses: azure/webapps-deploy@v2
-        with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME_EMAIL_SENDER }}
-          publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE_EMAIL_SENDER }}
-          package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-  
+ 
   deploy_prod:
     needs: build
-    if: github.ref == 'refs/heads/master'
     environment: 'prod'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Removed EmailSender.build-deploy.yml from the watch list in the Email Sender service's build workflow and renamed it to EmailSender.deploy.yml. This aims to segregate the build and deployment processes, facilitating improved manageability and troubleshooting since each process now has a dedicated workflow file